### PR TITLE
PDF and zip responses return bytes (fixes #27)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -262,7 +262,7 @@ Kwargs:
 
     # get Value Report in PDF format with "full" report_type.
     result = client.property.value_report("10216 N Willow Ave", "64157", format_type="pdf")
-    # result is binary data of the PDF.
+    # result is binary data of the PDF (See http://docs.python-requests.org/en/master/user/quickstart/#binary-response-content).
 
 Rental Report:
 ^^^^^^^^^^^^^^

--- a/housecanary/output.py
+++ b/housecanary/output.py
@@ -89,10 +89,10 @@ class ResponseOutputGenerator(OutputGenerator):
         return Response.create(endpoint_name, response_json, response)
 
     def process_pdf_response(self, response):
-        return response.text
+        return response.content
 
     def process_zip_response(self, response):
-        return response.text
+        return response.content
 
     @staticmethod
     def _parse_endpoint_name_from_url(request_url):


### PR DESCRIPTION
- Rather than returning a string, pdf and zip responses return bytes

Closes #27